### PR TITLE
Add support for locomotion and manipulation tasks

### DIFF
--- a/shimmy/dm_control_compatibility.py
+++ b/shimmy/dm_control_compatibility.py
@@ -6,25 +6,49 @@ and modified to modern gymnasium API
 """
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any
 
+import dm_env
 import gymnasium
 import numpy as np
-from dm_control.rl.control import Environment
+from dm_control import composer
+from dm_control.rl import control
 from gymnasium.core import ObsType
-from numpy.random import RandomState
+from gymnasium.envs.mujoco.mujoco_rendering import Viewer
 
 from shimmy.utils import dm_obs2gym_obs, dm_spec2gym_space
 
 
+class EnvType(Enum):
+    """The environment type."""
+
+    COMPOSER = 0
+    RL_CONTROL = 1
+
+
 class DmControlCompatibility(gymnasium.Env[ObsType, np.ndarray]):
-    """A compatibility wrapper that converts a dm-control environment into a gymnasium environment."""
+    """A compatibility wrapper that converts a dm-control environment into a gymnasium environment.
+
+    Dm-control actually has two Environments classes, `dm_control.composer.Environment` and
+    `dm_control.rl.control.Environment` that while both inherit from `dm_env.Environment`, they differ
+    in implementation.
+
+    For environment in `dm_control.suite` are `dm-control.rl.control.Environment` while
+    dm-control locomotion and manipulation environments use `dm-control.composer.Environment`.
+
+    This wrapper supports both Environment class through determining the base environment type.
+
+    Note:
+        dm-control uses `np.random.RandomState`, a legacy random number generator while gymnasium
+        uses `np.random.Generator`, therefore the return type of `np_random` is different from expected.
+    """
 
     metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 10}
 
     def __init__(
         self,
-        env: Environment,
+        env: composer.Environment | control.Environment | dm_env.Environment,
         render_mode: str | None = None,
         render_height: int = 84,
         render_width: int = 84,
@@ -32,6 +56,7 @@ class DmControlCompatibility(gymnasium.Env[ObsType, np.ndarray]):
     ):
         """Initialises the environment with a render mode along with render information."""
         self._env = env
+        self.env_type = self._find_env_type(env)
 
         self.observation_space = dm_spec2gym_space(env.observation_spec())
         self.action_space = dm_spec2gym_space(env.action_spec())
@@ -42,8 +67,7 @@ class DmControlCompatibility(gymnasium.Env[ObsType, np.ndarray]):
         self.camera_id = camera_id
 
         if self.render_mode == "human":
-            from gymnasium.envs.mujoco.mujoco_rendering import Viewer
-
+            # We use the gymnasium mujoco rendering, dm-control provides more complex rendering options.
             self.viewer = Viewer(
                 self._env.physics.model.ptr, self._env.physics.data.ptr
             )
@@ -54,7 +78,7 @@ class DmControlCompatibility(gymnasium.Env[ObsType, np.ndarray]):
         """Resets the dm-control environment."""
         super().reset(seed=seed)
         if seed is not None:
-            self.np_random = RandomState(seed=seed)
+            self.np_random = np.random.RandomState(seed=seed)
 
         timestep = self._env.reset()
         obs = dm_obs2gym_obs(timestep.observation)
@@ -118,12 +142,36 @@ class DmControlCompatibility(gymnasium.Env[ObsType, np.ndarray]):
     @property
     def np_random(self) -> np.random.RandomState:
         """This should be np.random.Generator but dm-control uses np.random.RandomState."""
-        return self._env.task._random
+        if self.env_type is EnvType.RL_CONTROL:
+            return self._env.task._random
+        else:
+            return self._env._random_state
 
     @np_random.setter
     def np_random(self, value: np.random.RandomState):
-        self._env.task._random = value
+        if self.env_type is EnvType.RL_CONTROL:
+            self._env.task._random = value
+        else:
+            self._env._random_state = value
 
     def __getattr__(self, item: str):
         """If the attribute is missing, try getting the attribute from dm_control env."""
         return getattr(self._env, item)
+
+    def _find_env_type(self, env) -> EnvType:
+        """Tries to discover env types, in particular for environments with wrappers."""
+        if isinstance(env, composer.Environment):
+            return EnvType.COMPOSER
+        elif isinstance(env, control.Environment):
+            return EnvType.RL_CONTROL
+        else:
+            assert isinstance(env, dm_env.Environment)
+
+            if hasattr(env, "_env"):
+                return self._find_env_type(env._env)
+            elif hasattr(env, "env"):
+                return self._find_env_type(env.env)
+            else:
+                raise AttributeError(
+                    f"Can't know the dm-control environment type, actual type: {type(env)}"
+                )

--- a/shimmy/registration.py
+++ b/shimmy/registration.py
@@ -2,13 +2,14 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any
+from typing import Any, Callable
 
+import numpy as np
 from gymnasium.envs.registration import register
 
 from shimmy.dm_control_compatibility import DmControlCompatibility
 
-DM_CONTROL_ENVS = (
+DM_CONTROL_SUITE_ENVS = (
     ("acrobot", "swingup"),
     ("acrobot", "swingup_sparse"),
     ("ball_in_cup", "catch"),
@@ -62,14 +63,52 @@ DM_CONTROL_ENVS = (
 )
 
 
+DM_CONTROL_MANIPULATION_ENVS = (
+    "stack_2_bricks_features",
+    "stack_2_bricks_vision",
+    "stack_2_bricks_moveable_base_features",
+    "stack_2_bricks_moveable_base_vision",
+    "stack_3_bricks_features",
+    "stack_3_bricks_vision",
+    "stack_3_bricks_random_order_features",
+    "stack_2_of_3_bricks_random_order_features",
+    "stack_2_of_3_bricks_random_order_vision",
+    "reassemble_3_bricks_fixed_order_features",
+    "reassemble_3_bricks_fixed_order_vision",
+    "reassemble_5_bricks_random_order_features",
+    "reassemble_5_bricks_random_order_vision",
+    "lift_brick_features",
+    "lift_brick_vision",
+    "lift_large_box_features",
+    "lift_large_box_vision",
+    "place_brick_features",
+    "place_brick_vision",
+    "place_cradle_features",
+    "place_cradle_vision",
+    "reach_duplo_features",
+    "reach_duplo_vision",
+    "reach_site_features",
+    "reach_site_vision",
+)
+
+
 def _register_dm_control_envs():
     """Registers all dm-control environments in gymnasium."""
     try:
-        import dm_control.suite
+        import dm_control
     except ImportError:
         return
 
-    def _make_dm_control_env(
+    # Add generic environment support
+    def _make_dm_control_generic_env(env, **render_kwargs):
+        return DmControlCompatibility(env, **render_kwargs)
+
+    register("dm_control/compatibility-env-v0", _make_dm_control_generic_env)
+
+    # Register all suite environments
+    import dm_control.suite
+
+    def _make_dm_control_suite_env(
         domain_name: str,
         task_name: str,
         task_kwargs: dict[str, Any] | None = None,
@@ -77,6 +116,7 @@ def _register_dm_control_envs():
         visualize_reward: bool = False,
         **render_kwargs,
     ):
+        """The entry_point function for registration of dm-control environments."""
         env = dm_control.suite.load(
             domain_name=domain_name,
             task_name=task_name,
@@ -86,12 +126,62 @@ def _register_dm_control_envs():
         )
         return DmControlCompatibility(env, **render_kwargs)
 
-    for _domain_name, _task_name in DM_CONTROL_ENVS:
+    for _domain_name, _task_name in DM_CONTROL_SUITE_ENVS:
         register(
             f"dm_control/{_domain_name}-{_task_name}-v0",
             partial(
-                _make_dm_control_env, domain_name=_domain_name, task_name=_task_name
+                _make_dm_control_suite_env,
+                domain_name=_domain_name,
+                task_name=_task_name,
             ),
+        )
+
+    # Register all example locomotion environments
+    # Listed in https://github.com/deepmind/dm_control/blob/main/dm_control/locomotion/examples/examples_test.py
+    from dm_control import composer
+    from dm_control.locomotion.examples import (
+        basic_cmu_2019,
+        basic_rodent_2020,
+        cmu_2020_tracking,
+    )
+
+    def _make_dm_control_example_locomotion_env(
+        env_fn: Callable[[np.random.RandomState | None], composer.Environment],
+        random_state: np.random.RandomState | None = None,
+        **render_kwargs,
+    ):
+        return DmControlCompatibility(env_fn(random_state), **render_kwargs)
+
+    for locomotion_env, nondeterministic in (
+        (basic_cmu_2019.cmu_humanoid_run_walls, False),
+        (basic_cmu_2019.cmu_humanoid_run_gaps, False),
+        (basic_cmu_2019.cmu_humanoid_go_to_target, False),
+        (basic_cmu_2019.cmu_humanoid_maze_forage, True),
+        (basic_cmu_2019.cmu_humanoid_heterogeneous_forage, True),
+        (basic_rodent_2020.rodent_escape_bowl, False),
+        (basic_rodent_2020.rodent_run_gaps, False),
+        (basic_rodent_2020.rodent_maze_forage, True),
+        (basic_rodent_2020.rodent_two_touch, True),
+        # (cmu_2020_tracking.cmu_humanoid_tracking, False),
+    ):
+        register(
+            f"dm_control/{locomotion_env.__name__.title().replace('_', '')}-v0",
+            partial(_make_dm_control_example_locomotion_env, env_fn=locomotion_env),
+            nondeterministic=nondeterministic,
+        )
+
+    # Register all manipulation environments
+    import dm_control.manipulation
+
+    def _make_dm_control_manipulation_env(env_name: str, **render_kwargs):
+        env = dm_control.manipulation.load(env_name)
+        return DmControlCompatibility(env, **render_kwargs)
+
+    for env_name in DM_CONTROL_MANIPULATION_ENVS:
+        register(
+            f"dm_control/{env_name}-v0",
+            partial(_make_dm_control_manipulation_env, env_name=env_name),
+            nondeterministic=env_name.startswith("reassemble_5_bricks_random_order"),
         )
 
 

--- a/tests/test_dm_control.py
+++ b/tests/test_dm_control.py
@@ -3,28 +3,37 @@ import warnings
 from typing import Callable
 
 import dm_control.suite
-import dm_env
 import gymnasium as gym
 import numpy as np
 import pytest
+from dm_control import composer
+from dm_control.locomotion.examples.basic_cmu_2019 import cmu_humanoid_run_walls
 from dm_control.suite.wrappers import (
     action_noise,
     action_scale,
     mujoco_profiling,
     pixels,
 )
+from gymnasium.envs.registration import registry
 from gymnasium.error import Error
 from gymnasium.utils.env_checker import check_env, data_equivalence
 
 from shimmy.dm_control_compatibility import DmControlCompatibility
-from shimmy.registration import DM_CONTROL_ENVS
+from shimmy.registration import DM_CONTROL_SUITE_ENVS
+
+DM_CONTROL_ENV_IDS = [
+    env_id
+    for env_id in registry
+    if env_id.startswith("dm_control") and env_id != "dm_control/compatibility-env-v0"
+]
 
 
-def test_dm_control_envs():
+def test_dm_control_suite_envs():
     """Tests that all DM_CONTROL_ENVS are equal to the known dm-control.suite tasks."""
-    assert dm_control.suite.ALL_TASKS == DM_CONTROL_ENVS
+    assert dm_control.suite.ALL_TASKS == DM_CONTROL_SUITE_ENVS
 
 
+# todo - gymnasium v27 should remove the need for some of these warnings
 CHECK_ENV_IGNORE_WARNINGS = [
     f"\x1b[33mWARN: {message}\x1b[0m"
     for message in [
@@ -35,14 +44,23 @@ CHECK_ENV_IGNORE_WARNINGS = [
         "A Box observation space has an unconventional shape (neither an image, nor a 1D vector). We recommend flattening the observation to have only a 1D vector or use a custom policy to properly process the data. Actual observation shape: (8, 2)",
         "A Box observation space has an unconventional shape (neither an image, nor a 1D vector). We recommend flattening the observation to have only a 1D vector or use a custom policy to properly process the data. Actual observation shape: (2, 4)",
         "A Box observation space has an unconventional shape (neither an image, nor a 1D vector). We recommend flattening the observation to have only a 1D vector or use a custom policy to properly process the data. Actual observation shape: (4, 4)",
+        "A Box observation space has an unconventional shape (neither an image, nor a 1D vector). We recommend flattening the observation to have only a 1D vector or use a custom policy to properly process the data. Actual observation shape: (1, 3)",
+        "A Box observation space has an unconventional shape (neither an image, nor a 1D vector). We recommend flattening the observation to have only a 1D vector or use a custom policy to properly process the data. Actual observation shape: (1, 84, 84, 3)",
+        "A Box observation space has an unconventional shape (neither an image, nor a 1D vector). We recommend flattening the observation to have only a 1D vector or use a custom policy to properly process the data. Actual observation shape: (1, 2)",
+        "A Box observation space has an unconventional shape (neither an image, nor a 1D vector). We recommend flattening the observation to have only a 1D vector or use a custom policy to properly process the data. Actual observation shape: (1, 6)",
+        "A Box observation space has an unconventional shape (neither an image, nor a 1D vector). We recommend flattening the observation to have only a 1D vector or use a custom policy to properly process the data. Actual observation shape: (1, 4)",
+        "A Box observation space has an unconventional shape (neither an image, nor a 1D vector). We recommend flattening the observation to have only a 1D vector or use a custom policy to properly process the data. Actual observation shape: (1, 9)",
+        "A Box observation space has an unconventional shape (neither an image, nor a 1D vector). We recommend flattening the observation to have only a 1D vector or use a custom policy to properly process the data. Actual observation shape: (1, 5)",
+        "It seems a Box observation space is an image but the `dtype` is not `np.uint8`, actual type: float64. If the Box observation space is not an image, we recommend flattening the observation to have only a 1D vector.",
+        "It seems a Box observation space is an image but the upper and lower bounds are not in [0, 255]. Generally, CNN policies assume observations are within that range, so you may encounter an issue if the observation values are not.",
     ]
 ]
 
 
-@pytest.mark.parametrize("domain_name, task_name", DM_CONTROL_ENVS)
-def test_check_env(domain_name, task_name):
+@pytest.mark.parametrize("env_id", DM_CONTROL_ENV_IDS)
+def test_check_env(env_id):
     """Check that environment pass the gymnasium check_env."""
-    env = gym.make(f"dm_control/{domain_name}-{task_name}-v0")
+    env = gym.make(env_id)
 
     with warnings.catch_warnings(record=True) as caught_warnings:
         check_env(env.unwrapped)
@@ -55,13 +73,13 @@ def test_check_env(domain_name, task_name):
     env.close()
 
 
-@pytest.mark.parametrize("domain_name, task_name", DM_CONTROL_ENVS)
-def test_seeding(domain_name, task_name):
+@pytest.mark.parametrize("env_id", DM_CONTROL_ENV_IDS)
+def test_seeding(env_id):
     """Test that dm-control seeding works."""
-    env_1 = gym.make(f"dm_control/{domain_name}-{task_name}-v0")
-    env_2 = gym.make(f"dm_control/{domain_name}-{task_name}-v0")
+    env_1 = gym.make(env_id)
+    env_2 = gym.make(env_id)
 
-    if domain_name == "lqr":
+    if "lqr" in env_id or env_1.spec.nondeterministic:
         # LQR fails this test currently.
         return
 
@@ -85,9 +103,8 @@ def test_seeding(domain_name, task_name):
 @pytest.mark.parametrize("camera_id", [0, 1])
 def test_rendering_camera_id(camera_id):
     """Test that dm-control rendering works."""
-    domain_name, task_name = DM_CONTROL_ENVS[0]
     env = gym.make(
-        f"dm_control/{domain_name}-{task_name}-v0",
+        DM_CONTROL_ENV_IDS[0],
         render_mode="rgb_array",
         camera_id=camera_id,
     )
@@ -103,9 +120,8 @@ def test_rendering_camera_id(camera_id):
 @pytest.mark.parametrize("height,width", [(84, 84), (48, 48), (128, 128), (100, 200)])
 def test_render_height_widths(height, width):
     """Tests that dm-control rendering heights and widths works."""
-    domain_name, task_name = DM_CONTROL_ENVS[0]
     env = gym.make(
-        f"dm_control/{domain_name}-{task_name}-v0",
+        DM_CONTROL_ENV_IDS[0],
         render_mode="rgb_array",
         render_height=height,
         render_width=width,
@@ -127,13 +143,20 @@ def test_render_height_widths(height, width):
     ids=["action noise", "action scale", "mujoco profiling", "pixels"],
 )
 def test_dm_control_wrappers(
-    wrapper_fn: Callable[[dm_env.Environment], dm_env.Environment]
+    wrapper_fn: Callable[[composer.Environment], composer.Environment],
 ):
     """Test the built-in dm-control wrappers."""
-    domain_name, task_name = DM_CONTROL_ENVS[0]
+    dm_control_env = dm_control.suite.load(*DM_CONTROL_SUITE_ENVS[0])
 
-    dm_env = dm_control.suite.load(domain_name, task_name)
-    wrapped_env = wrapper_fn(dm_env)
+    if wrapper_fn is action_noise.Wrapper and isinstance(
+        dm_control_env, composer.Environment
+    ):
+        return
+    wrapped_env = wrapper_fn(dm_control_env)
 
     env = DmControlCompatibility(wrapped_env)
     check_env(env)
+
+    env = gym.make("dm_control/compatibility-env-v0", env=wrapped_env)
+    check_env(env)
+    env.close()


### PR DESCRIPTION
This PR adds support for more dm-control environments.

Dm-control contains primarily three types environments
* suite - `dm-control.suite.load` uses `dm-control.rl.control.Environment` for the base environments
* manipulation - `dm-control.manipulation.load` uses `dm-control.composer.Environment` 
* locomotion - Several example locomotion environments are supported that use `dm-control.composer.Environment`. 

Due to `dm-control` containing two types of Environments then the `DmCompatibilityEnv` aims to support both types environments automatically.

Known issues: several of the environments are not deterministic, thus we use the `nondeterministic` when registering them. For future works, we should investigate these environments to see if we can eliminate the sources of randomness. 