### PR TITLE
Fix dm-control environment step conversion 

### DIFF
--- a/shimmy/utils/dm_env.py
+++ b/shimmy/utils/dm_env.py
@@ -61,7 +61,7 @@ def dm_control_step2gym_step(
     # set terminated and truncated
     terminated, truncated = False, False
     if timestep.last():
-        if timestep.discount == 0:
+        if timestep.discount == 1.0:
             truncated = True
         else:
             terminated = True

--- a/shimmy/utils/dm_env.py
+++ b/shimmy/utils/dm_env.py
@@ -61,7 +61,7 @@ def dm_control_step2gym_step(
     # set terminated and truncated
     terminated, truncated = False, False
     if timestep.last():
-        if timestep.discount == 1.0:
+        if timestep.discount > 0:
             truncated = True
         else:
             terminated = True

--- a/shimmy/utils/dm_env.py
+++ b/shimmy/utils/dm_env.py
@@ -61,6 +61,7 @@ def dm_control_step2gym_step(
     # set terminated and truncated
     terminated, truncated = False, False
     if timestep.last():
+        # https://github.com/deepmind/dm_env/blob/master/docs/index.md#example-sequences
         if timestep.discount > 0:
             truncated = True
         else:

--- a/tests/test_gym.py
+++ b/tests/test_gym.py
@@ -19,7 +19,7 @@ CHECK_ENV_IGNORE_WARNINGS = [
         "A Box observation space maximum value is -infinity. This is probably too high.",
         "For Box action spaces, we recommend using a symmetric and normalized space (range=[-1, 1] or [0, 1]). See https://stable-baselines3.readthedocs.io/en/master/guide/rl_tips.html for more information.",
     ]
-]
+] + ["`np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)"]
 
 # We do not test Atari environment's here because we check all variants of Pong in test_envs.py (There are too many Atari environments)
 CLASSIC_CONTROL_ENVS = [
@@ -40,10 +40,8 @@ def test_gym_conversion_by_id(env_id):
         check_env(env, skip_render_check=True)
 
     for warning in caught_warnings:
-        if (
-            isinstance(warning.message, Warning)
-            and warning.message.args[0] not in CHECK_ENV_IGNORE_WARNINGS
-        ):
+        assert isinstance(warning.message, Warning)
+        if warning.message.args[0] not in CHECK_ENV_IGNORE_WARNINGS:
             raise Error(f"Unexpected warning: {warning.message}")
 
     env.close()
@@ -63,10 +61,9 @@ def test_gym_conversion_instantiated(env_id):
         check_env(env, skip_render_check=True)
 
     for warning in caught_warnings:
-        if (
-            isinstance(warning.message, Warning)
-            and warning.message.args[0] not in CHECK_ENV_IGNORE_WARNINGS
-        ):
+        assert isinstance(warning.message, Warning)
+
+        if warning.message.args[0] not in CHECK_ENV_IGNORE_WARNINGS:
             raise Error(f"Unexpected warning: {warning.message}")
 
     env.close()


### PR DESCRIPTION
https://github.com/Farama-Foundation/Shimmy/issues/26#issuecomment-1397661966 noted that the dm-control step conversion to gymnasium step was incorrectly implemented. 

This was as we were checking that the discount on truncation time steps was `0` rather than `>0` which is what the dm-env specify. See the second example sequence
https://github.com/deepmind/dm_env/blob/master/docs/index.md#example-sequences

This is followed by dm-control with a `discount=1.0` when truncated, https://github.com/deepmind/dm_control/blob/3c67a42d021b97808fcc075c0c468d78f0c2233f/dm_control/rl/control.py#L110-L122 
