### PR TITLE
Update dm-control, update dm-control list of tasks and reduce warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ extras = {
     "gym": ["gym>=0.26"],
     "atari": ["ale-py~=0.8.0"],
     # "imageio" should be "gymnasium[mujoco]>=0.26" but there are install conflicts
-    "dm-control": ["dm-control>=1.0.8", "imageio", "h5py>=3.7.0"],
-    "dm-control-multi-agent": ["dm-control>=1.0.8", "pettingzoo>=1.22"],
+    "dm-control": ["dm-control>=1.0.10", "imageio", "h5py>=3.7.0"],
+    "dm-control-multi-agent": ["dm-control>=1.0.10", "pettingzoo>=1.22"],
     "openspiel": ["open_spiel>=1.2", "pettingzoo>=1.22"],
 }
 extras["all"] = list({lib for libs in extras.values() for lib in libs})

--- a/shimmy/utils/envs_configs.py
+++ b/shimmy/utils/envs_configs.py
@@ -28,6 +28,7 @@ DM_CONTROL_SUITE_ENVS = (
     ("humanoid", "run"),
     ("humanoid", "run_pure_state"),
     ("humanoid_CMU", "stand"),
+    ('humanoid_CMU', 'walk'),
     ("humanoid_CMU", "run"),
     ("lqr", "lqr_2_1"),
     ("lqr", "lqr_6_2"),

--- a/shimmy/utils/envs_configs.py
+++ b/shimmy/utils/envs_configs.py
@@ -28,7 +28,7 @@ DM_CONTROL_SUITE_ENVS = (
     ("humanoid", "run"),
     ("humanoid", "run_pure_state"),
     ("humanoid_CMU", "stand"),
-    ('humanoid_CMU', 'walk'),
+    ("humanoid_CMU", "walk"),
     ("humanoid_CMU", "run"),
     ("lqr", "lqr_2_1"),
     ("lqr", "lqr_6_2"),

--- a/tests/test_dm_control.py
+++ b/tests/test_dm_control.py
@@ -7,7 +7,6 @@ import gymnasium as gym
 import numpy as np
 import pytest
 from dm_control import composer
-from dm_control.locomotion.examples.basic_cmu_2019 import cmu_humanoid_run_walls
 from dm_control.suite.wrappers import (
     action_noise,
     action_scale,
@@ -64,7 +63,7 @@ CHECK_ENV_IGNORE_WARNINGS.append(
 @pytest.mark.parametrize("env_id", DM_CONTROL_ENV_IDS)
 def test_check_env(env_id):
     """Check that environment pass the gymnasium check_env."""
-    env = gym.make(env_id)
+    env = gym.make(env_id, disable_env_checker=True)
 
     with warnings.catch_warnings(record=True) as caught_warnings:
         check_env(env.unwrapped)
@@ -169,6 +168,6 @@ def test_dm_control_wrappers(
         if warning_message.message.args[0] not in CHECK_ENV_IGNORE_WARNINGS:
             raise Error(f"Unexpected warning: {warning_message.message}")
 
-    env = gym.make("dm_control/compatibility-env-v0", env=wrapped_env)
-    check_env(env, skip_render_check=True)
+    env = gym.make("dm_control/compatibility-env-v0", env=wrapped_env, disable_env_checker=True)
+    check_env(env.unwrapped, skip_render_check=True)
     env.close()

--- a/tests/test_dm_control.py
+++ b/tests/test_dm_control.py
@@ -168,6 +168,8 @@ def test_dm_control_wrappers(
         if warning_message.message.args[0] not in CHECK_ENV_IGNORE_WARNINGS:
             raise Error(f"Unexpected warning: {warning_message.message}")
 
-    env = gym.make("dm_control/compatibility-env-v0", env=wrapped_env, disable_env_checker=True)
+    env = gym.make(
+        "dm_control/compatibility-env-v0", env=wrapped_env, disable_env_checker=True
+    )
     check_env(env.unwrapped, skip_render_check=True)
     env.close()


### PR DESCRIPTION
Due to an update in `dm-control==1.10.0` the CI started to fail. This PR fixes thought issues to allow other PR to pass 