### PR TITLE
Fix typo in gym V21 wrapper, update documentation with full usage

### DIFF
--- a/docs/contents/gym.md
+++ b/docs/contents/gym.md
@@ -13,25 +13,47 @@ Shimmy provides compatibility wrappers to convert Gym [V26](https://github.com/o
 ```
 
 ### Installation
+First, install shimmy:
 ```
 pip install shimmy[gym]
 ```
 
+Then, install the corresponding version of Gym. 
+
+Gym V21:
+
+```
+pip install gym==0.21.0
+```
+
+Gym V26:
+```
+pip install gym==0.26.1
+```
+
 ### Usage
 
-Load a `gym` environment:
+Note: the following code requires gym V21 installed: )
+
+Load a `gym` V21 environment: 
 ```python
 import gymnasium as gym
 
-env = gym.make("GymV21CompatibilityV0", env_name="...")
+env = gym.make("GymV21Environment-v0", env_id="CartPole-v1", render_mode="human")
 ```
 
-[//]: # (Run the environment:)
-[//]: # (```python)
+Run the environment:
+```python
+observation, info = env.reset(seed=42)
+for _ in range(1000):
+   action = env.action_space.sample()  # this is where you would insert your policy
+   observation, reward, terminated, truncated, info = env.step(action)
 
-[//]: # ()
-[//]: # (```)
-[//]: # (TODO: make this a full example)
+   if terminated or truncated:
+      observation, info = env.reset()
+env.close()
+```
+
 
 ### Class Description
 ```{eval-rst}

--- a/shimmy/openai_gym_compatibility.py
+++ b/shimmy/openai_gym_compatibility.py
@@ -238,10 +238,12 @@ class GymV21CompatibilityV0(gymnasium.Env[ObsType, ActType]):
                 f"Gym v21 environment do not accept options as a reset parameter, options={options}"
             )
 
+        obs = self.gym_env.reset()
+
         if self.render_mode == "human":
             self.render()
 
-        return self.gym_env.reset(), {}
+        return obs, {}
 
     def step(self, action: ActType) -> tuple[Any, float, bool, bool, dict]:
         """Steps through the environment.


### PR DESCRIPTION
# Description

This PR adds full example usage for the gym compatibility wrapper, and fixes a bug in the V21 code.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
