### PR TITLE
Fix setup.py encoding problem on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 def get_description():
     """Gets the description from the readme."""
-    with open("README.md") as fh:
+    with open("README.md", encoding="utf-8") as fh:
         long_description = ""
         header_count = 0
         for line in fh:


### PR DESCRIPTION
# Description

Fix `UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 3356: character maps to <undefined>` by specifying the encoding (utf-8). I think this only happens on Windows.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

### Screenshots

![image](https://user-images.githubusercontent.com/14279775/230665816-91ca9fd8-848c-4049-82a5-34d1b180b31b.png)
