### PR TITLE
Update melting pot docs to include installation script

### DIFF
--- a/docs/contents/meltingpot.md
+++ b/docs/contents/meltingpot.md
@@ -18,7 +18,7 @@ Shimmy provides compatibility wrappers to convert all [Melting Pot](https://gith
 pip install shimmy[melting-pot]
 ```
 
-Melting Pot must be installed manually, see [installation](https://github.com/deepmind/meltingpot#installation).
+Melting Pot is not distributed via [pypi](https://pypi.org/) and must be installed manually. We provide an [installation script](https://github.com/Farama-Foundation/Shimmy/blob/main/scripts/install_melting_pot.sh) (compatible with macOS and linux) to clone the melting pot repository, install bazel, and run the included installation scripts. For troubleshooting,  refer to the official [installation instructions](https://github.com/deepmind/meltingpot#installation).
 
 ### Usage (Multi agent)
 Load a `meltingpot` environment:


### PR DESCRIPTION
# Description

This is a quick fix to link our installation script on the documentation for melting pot, and explain that the user should refer to the official documentation for troubleshooting.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
