### PR TITLE
Support multi_camera and depth_array render mode for dm environments

### DIFF
--- a/shimmy/dm_control_compatibility.py
+++ b/shimmy/dm_control_compatibility.py
@@ -6,20 +6,20 @@ and modified to modern gymnasium API
 """
 from __future__ import annotations
 
-from enum import Enum
-from typing import Any, Optional, Callable
-
 import math
+from enum import Enum
+from typing import Any, Callable, Optional
+
 import dm_env
 import gymnasium
+import mujoco
 import numpy as np
 from dm_control import composer
-from dm_control.rl import control
 from dm_control.mujoco.engine import Physics as MujocoEnginePhysics
+from dm_control.rl import control
 from gymnasium.core import ObsType
 from gymnasium.envs.mujoco.mujoco_rendering import MujocoRenderer
 from gymnasium.utils import EzPickle
-import mujoco
 
 from shimmy.utils.dm_env import dm_env_step2gym_step, dm_spec2gym_space
 
@@ -50,7 +50,10 @@ class DmControlCompatibilityV0(gymnasium.Env[ObsType, np.ndarray], EzPickle):
         uses `np.random.Generator`, therefore the return type of `np_random` is different from expected.
     """
 
-    metadata = {"render_modes": ["human", "rgb_array", "multi_camera", "depth_array"], "render_fps": 10}
+    metadata = {
+        "render_modes": ["human", "rgb_array", "multi_camera", "depth_array"],
+        "render_fps": 10,
+    }
 
     def __init__(
         self,
@@ -59,7 +62,8 @@ class DmControlCompatibilityV0(gymnasium.Env[ObsType, np.ndarray], EzPickle):
         render_height: int = 84,
         render_width: int = 84,
         camera_id: int = 0,
-        render_scene_callback : Optional[Callable[[MujocoEnginePhysics, mujoco.MjvScene],None]] = None
+        render_scene_callback: None
+        | (Callable[[MujocoEnginePhysics, mujoco.MjvScene], None]) = None,
     ):
         """Initialises the environment with a render mode along with render information."""
         EzPickle.__init__(
@@ -124,32 +128,39 @@ class DmControlCompatibilityV0(gymnasium.Env[ObsType, np.ndarray], EzPickle):
                 height=self.render_height,
                 width=self.render_width,
                 camera_id=self.camera_id,
-                scene_callback=self.render_scene_callback
+                scene_callback=self.render_scene_callback,
             )
         elif self.render_mode == "depth_array":
-             return self._env.physics.render(
+            return self._env.physics.render(
                 height=self.render_height,
                 width=self.render_width,
                 camera_id=self.camera_id,
                 depth=True,
-                scene_callback=self.render_scene_callback
+                scene_callback=self.render_scene_callback,
             )
         elif self.render_mode == "multi_camera":
             physics = self._env.physics
             num_cameras = physics.model.ncam
             num_columns = int(math.ceil(math.sqrt(num_cameras)))
             num_rows = int(math.ceil(float(num_cameras) / num_columns))
-            frame = np.zeros((num_rows * self.render_height, num_columns * self.render_width, 3), dtype=np.uint8)
+            frame = np.zeros(
+                (num_rows * self.render_height, num_columns * self.render_width, 3),
+                dtype=np.uint8,
+            )
             for col in range(num_columns):
                 for row in range(num_rows):
                     camera_id = row * num_columns + col
                     if camera_id >= num_cameras:
                         break
                     subframe = physics.render(
-                        height=self.render_height, width=self.render_width, camera_id=camera_id, scene_callback=self.render_scene_callback
+                        height=self.render_height,
+                        width=self.render_width,
+                        camera_id=camera_id,
+                        scene_callback=self.render_scene_callback,
                     )
                     frame[
-                        row * self.render_height : (row + 1) * self.render_height, col * self.render_width : (col + 1) * self.render_width
+                        row * self.render_height : (row + 1) * self.render_height,
+                        col * self.render_width : (col + 1) * self.render_width,
                     ] = subframe
             return frame
 

--- a/tests/test_dm_control.py
+++ b/tests/test_dm_control.py
@@ -150,6 +150,39 @@ def test_rendering_camera_id(camera_id):
 
     env.close()
 
+@pytest.mark.parametrize("height,width", [(84, 84), (48, 48), (128, 128), (100, 200)])
+def test_rendering_multiple_cameras(height, width):
+    """Test that multi_camera rendering mode works for dm-control environments."""
+    env = gym.make(
+        DM_CONTROL_ENV_IDS[0],
+        render_mode="multi_camera",
+        render_height=height,
+        render_width=width
+    )
+    env.reset()
+    frames = []
+    for _ in range(10):
+        frames.append(env.render())
+        env.step(env.action_space.sample())
+
+    env.close()
+
+@pytest.mark.parametrize("height,width", [(84, 84), (48, 48), (128, 128), (100, 200)])
+def test_rendering_depth(height, width):
+    """Test that depth rendering mode works for dm-control environments"""
+    env = gym.make(
+        DM_CONTROL_ENV_IDS[0],
+        render_mode="depth_array",
+        render_height=height,
+        render_width=width
+    )
+    env.reset()
+    frames = []
+    for _ in range(10):
+        frames.append(env.render())
+        env.step(env.action_space.sample())
+
+    env.close()
 
 @pytest.mark.parametrize("height,width", [(84, 84), (48, 48), (128, 128), (100, 200)])
 def test_render_height_widths(height, width):

--- a/tests/test_dm_control.py
+++ b/tests/test_dm_control.py
@@ -150,6 +150,7 @@ def test_rendering_camera_id(camera_id):
 
     env.close()
 
+
 @pytest.mark.parametrize("height,width", [(84, 84), (48, 48), (128, 128), (100, 200)])
 def test_rendering_multiple_cameras(height, width):
     """Test that multi_camera rendering mode works for dm-control environments."""
@@ -157,7 +158,7 @@ def test_rendering_multiple_cameras(height, width):
         DM_CONTROL_ENV_IDS[0],
         render_mode="multi_camera",
         render_height=height,
-        render_width=width
+        render_width=width,
     )
     env.reset()
     frames = []
@@ -167,14 +168,15 @@ def test_rendering_multiple_cameras(height, width):
 
     env.close()
 
+
 @pytest.mark.parametrize("height,width", [(84, 84), (48, 48), (128, 128), (100, 200)])
 def test_rendering_depth(height, width):
-    """Test that depth rendering mode works for dm-control environments"""
+    """Test that depth rendering mode works for dm-control environments."""
     env = gym.make(
         DM_CONTROL_ENV_IDS[0],
         render_mode="depth_array",
         render_height=height,
-        render_width=width
+        render_width=width,
     )
     env.reset()
     frames = []
@@ -183,6 +185,7 @@ def test_rendering_depth(height, width):
         env.step(env.action_space.sample())
 
     env.close()
+
 
 @pytest.mark.parametrize("height,width", [(84, 84), (48, 48), (128, 128), (100, 200)])
 def test_render_height_widths(height, width):


### PR DESCRIPTION
# Description

This pull request implements #67 

## Type of change

- New feature (non-breaking change which adds functionality)

### Screenshots

Before: Only one camera supported in `DmControlCompatibilityV0`
![Before](https://user-images.githubusercontent.com/18230652/232661503-c5ddca92-65d5-4fbd-8589-548d63caf28f.png)

After: 

Stacking cameras in `DmControlCompatibilityV0` by using `multi_camera` render mode
![After](https://user-images.githubusercontent.com/18230652/232661627-03e7c1e1-33de-4b91-9ebe-fb80401128cf.png)

Also, Depth Image Rendering in `DmControlCompatibilityV0` by using `depth_array` render_mode

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
