### PR TITLE
Update metadata for OpenSpiel wrapper (non parallelizable because AEC)

### DIFF
--- a/shimmy/dm_control_multiagent_compatibility.py
+++ b/shimmy/dm_control_multiagent_compatibility.py
@@ -74,7 +74,7 @@ class DmControlMultiAgentCompatibilityV0(ParallelEnv, EzPickle):
     using MuJoCo physics. This compatibility wrapper converts a dm-control environment into a gymnasium environment.
     """
 
-    metadata = {"render_modes": ["human"]}
+    metadata = {"render_modes": ["human"], "name": "DmControlMultiAgentCompatibilityV0"}
 
     def __init__(
         self,

--- a/shimmy/meltingpot_compatibility.py
+++ b/shimmy/meltingpot_compatibility.py
@@ -35,7 +35,10 @@ class MeltingPotCompatibilityV0(ParallelEnv, EzPickle):
     on which to train agents, and over 256 unique test scenarios on which to evaluate these trained agents.
     """
 
-    metadata = {"render_modes": ["human", "rgb_array"]}
+    metadata = {
+        "render_modes": ["human", "rgb_array"],
+        "name": "MeltingPotCompatibilityV0",
+    }
 
     PLAYER_STR_FORMAT = "player_{index}"
     MAX_CYCLES = 1000

--- a/shimmy/openspiel_compatibility.py
+++ b/shimmy/openspiel_compatibility.py
@@ -22,7 +22,11 @@ class OpenSpielCompatibilityV0(pz.AECEnv, EzPickle):
     (partially- and fully- observable) grid worlds and social dilemmas.
     """
 
-    metadata = {"render_modes": ["human"]}
+    metadata = {
+        "render_modes": ["human"],
+        "name": "OpenSpielCompatibilityV0",
+        "is_parallelizable": False,
+    }
 
     def __init__(
         self,


### PR DESCRIPTION
# Description

This is a minor PR updating the metadata tags for the OpenSpiel wrapper, which is loaded as AEC environments so should by default not be parallelizable, and add a name to the environment. 

Edit: I decided to replicate the same changes to the other multi-agent environments, as PettingZoo native environments all have this tag. If we don't want to do this change we can close this PR. 

The parallelizable bit is only relevant for pettingzoo conversion wrappers, which check for the flag and warn the user that not all AEC envs are able to be converted to parallel envs. Some OpenSpiel envs might be able to work but I think most likely will not. Could test this further, but figured I'd throw this up just to see what people think. Might not be necessary and the user can figure it out on their own. 

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
