### PR TITLE
Update setup.py for gym v0.21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ version = get_version()
 header_count, long_description = get_description()
 
 extras = {
-    "gym-v21": ["gym>=0.21.0", "pyglet==1.5.11"],
+    "gym-v21": ["gym>=0.21.0,<0.26", "pyglet==1.5.11"],
     "gym-v26": ["gym>=0.26.2"],
     "atari": ["ale-py~=0.8.1"],
     # "imageio" should be "gymnasium[mujoco]>=0.26" but there are install conflicts


### PR DESCRIPTION
For "gym-v21", the installation is "gym>=0.21" however this allows gym==0.26 to be installed, failing the exact case. 

Additionally, we could look to add the same requirements as specified in https://github.com/openai/gym/issues/3211

