### PR TITLE
Fix dm-control `render_fps` and add `dt` function

### DIFF
--- a/bin/dm_lab.Dockerfile
+++ b/bin/dm_lab.Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get -y update \
     && apt-get install --no-install-recommends -y \
     build-essential curl freeglut3-dev gettext git libffi-dev libglu1-mesa \
     libglu1-mesa-dev libjpeg-dev liblua5.1-0-dev libosmesa6-dev \
-    libsdl2-dev lua5.1 pkg-config python-setuptools python3-dev \
+    libsdl2-dev lua5.1 pkg-config python3-dev \
     software-properties-common unzip zip zlib1g-dev g++
 
 # Install Bazel

--- a/bin/dm_lab.Dockerfile
+++ b/bin/dm_lab.Dockerfile
@@ -40,9 +40,9 @@ RUN if [ -f "pyproject.toml" ]; then \
 # Install DM lab requirements
 RUN apt-get -y update \
     && apt-get install --no-install-recommends -y \
-    build-essential curl freeglut3 gettext git libffi-dev libglu1-mesa \
+    build-essential curl freeglut3-dev gettext git libffi-dev libglu1-mesa \
     libglu1-mesa-dev libjpeg-dev liblua5.1-0-dev libosmesa6-dev \
-    libsdl2-dev lua5.1 pkg-config python3-dev \
+    libsdl2-dev lua5.1 pkg-config python-setuptools python3-dev \
     software-properties-common unzip zip zlib1g-dev g++
 
 # Install Bazel

--- a/bin/dm_lab.Dockerfile
+++ b/bin/dm_lab.Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get -y update \
     && apt-get install --no-install-recommends -y \
     build-essential curl freeglut3 gettext git libffi-dev libglu1-mesa \
     libglu1-mesa-dev libjpeg-dev liblua5.1-0-dev libosmesa6-dev \
-    libsdl2-dev lua5.1 pkg-config python-setuptools python3-dev \
+    libsdl2-dev lua5.1 pkg-config python3-dev \
     software-properties-common unzip zip zlib1g-dev g++
 
 # Install Bazel

--- a/shimmy/dm_control_compatibility.py
+++ b/shimmy/dm_control_compatibility.py
@@ -52,7 +52,7 @@ class DmControlCompatibilityV0(gymnasium.Env[ObsType, np.ndarray], EzPickle):
 
     metadata = {
         "render_modes": ["human", "rgb_array", "depth_array", "multi_camera"],
-        "render_fps": 10,
+        "render_fps": 10,  # this value is updated to use the `env.control_timesteps() * 1000`
     }
 
     def __init__(
@@ -78,7 +78,7 @@ class DmControlCompatibilityV0(gymnasium.Env[ObsType, np.ndarray], EzPickle):
             render_height (Optional[int]): height for rendering frame in pixels
             render_width (Optional[int]): width for rendering frame in pixels
             camera_id (Optional[int | str]): Optional camera name or index. Defaults to -1, the free
-                camera, which is always defined. A nonnegative integer or string
+                camera, which is always defined. A non-negative integer or string
                 corresponds to a fixed camera, which must be defined in the model XML.
                 If `camera_id` is a string then the camera must also be named.
             render_scene_callback (Optional[(Callable[[MujocoEnginePhysics, mujoco.MjvScene], None])]): Called after
@@ -91,7 +91,7 @@ class DmControlCompatibilityV0(gymnasium.Env[ObsType, np.ndarray], EzPickle):
         )
         self._env: Any = env
         self.env_type = self._find_env_type(env)
-        self.metadata["render_fps"] = self._env.control_timestep()
+        self.metadata["render_fps"] = self._env.control_timestep() * 1000
 
         self.observation_space = dm_spec2gym_space(env.observation_spec())
         self.action_space = dm_spec2gym_space(env.action_spec())
@@ -111,6 +111,10 @@ class DmControlCompatibilityV0(gymnasium.Env[ObsType, np.ndarray], EzPickle):
             self.viewer = MujocoRenderer(
                 self._env.physics.model.ptr, self._env.physics.data.ptr
             )
+
+    @property
+    def dt(self):
+        return self._env.control_timestep()
 
     def reset(
         self, *, seed: int | None = None, options: dict[str, Any] | None = None

--- a/shimmy/dm_control_compatibility.py
+++ b/shimmy/dm_control_compatibility.py
@@ -114,6 +114,7 @@ class DmControlCompatibilityV0(gymnasium.Env[ObsType, np.ndarray], EzPickle):
 
     @property
     def dt(self):
+        """Returns the environment control timestep which is equivalent to the number of actions per second."""
         return self._env.control_timestep()
 
     def reset(


### PR DESCRIPTION
Fixes dm-control render_fps as `env.control_timesteps` [returns the interval between agent actions in seconds.](https://github.com/deepmind/dm_control/blob/330c91f41a21eacadcf8316f0a071327e3f5c017/dm_control/rl/control.py#L163) Therefore the value needs multiplying by 1000 to make it the fps
Adds `dt` as requested in https://github.com/Farama-Foundation/Shimmy/issues/26