### PR TITLE
Fix documentation for installing multiple extras (remove space)

### DIFF
--- a/docs/content/getting_started.md
+++ b/docs/content/getting_started.md
@@ -12,7 +12,7 @@ pip install shimmy
 ```
 To install required dependencies for environments, specify them as follows:
 ```
-pip install shimmy[bsuite, atari]
+pip install shimmy[bsuite,atari]
 ```
 
 Choices: `gym-v21`, `gym-v26`, `atari`, `bsuite`, `dm-control`, `dm-control-multi-agent`, `openspiel`, `meltingpot`
@@ -20,7 +20,7 @@ Choices: `gym-v21`, `gym-v26`, `atari`, `bsuite`, `dm-control`, `dm-control-mult
 For development and testing:
 
 ```
-pip install shimmy[all, testing]
+pip install shimmy[all,testing]
 ```
 
 

--- a/docs/content/getting_started.md
+++ b/docs/content/getting_started.md
@@ -12,7 +12,7 @@ pip install shimmy
 ```
 To install required dependencies for environments, specify them as follows:
 ```
-pip install shimmy[bsuite,atari]
+pip install "shimmy[bsuite,atari]"
 ```
 
 Choices: `gym-v21`, `gym-v26`, `atari`, `bsuite`, `dm-control`, `dm-control-multi-agent`, `openspiel`, `meltingpot`

--- a/docs/content/getting_started.md
+++ b/docs/content/getting_started.md
@@ -20,7 +20,7 @@ Choices: `gym-v21`, `gym-v26`, `atari`, `bsuite`, `dm-control`, `dm-control-mult
 For development and testing:
 
 ```
-pip install shimmy[all,testing]
+pip install "shimmy[all,testing]"
 ```
 
 


### PR DESCRIPTION
# Description

Having a space in between extras causes errors when trying to install for example `pip install shimmy[all, testing]` whereas `pip install shimmy[all,testing]` works

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
