### PR TITLE
Add testing for human rendering, default_cam_config option in kwargs for customization

### DIFF
--- a/shimmy/dm_control_compatibility.py
+++ b/shimmy/dm_control_compatibility.py
@@ -130,7 +130,7 @@ class DmControlCompatibilityV0(gymnasium.Env[ObsType, np.ndarray], EzPickle):
         obs, reward, terminated, truncated, info = dm_env_step2gym_step(timestep)
 
         if self.render_mode == "human":
-            self.render()
+            self.viewer.render(self.render_mode)
 
         return (
             obs,
@@ -142,8 +142,6 @@ class DmControlCompatibilityV0(gymnasium.Env[ObsType, np.ndarray], EzPickle):
 
     def render(self) -> np.ndarray | None:
         """Renders the dm-control env."""
-        if self.render_mode == "human":
-            self.viewer.render(self.render_mode)
         if self.render_mode == "rgb_array":
             return self._env.physics.render(
                 **self.render_kwargs,


### PR DESCRIPTION
Addresses an issue raised in https://github.com/Farama-Foundation/Shimmy/issues/90

We could also add something that tests video recording like in https://github.com/Farama-Foundation/Shimmy/issues/15 just to ensure things still work, but probably not as important (ensuring human rendering works in this PR is much more important imo).

Only downside is some things need manual validation to see if the rendering kwargs actually do the right thing, and if the scene is frozen, but at the very least this ensures that the human rendering does work and that the args go through correctly, and makes it extremely easy for us to go through and check that things work (for example for troubleshooting the gymnasium mujoco rendering issue we hypothesized in that issue)

Got a little distracted digging into the mujoco rendering and then saw that you can specify the default_cam_config, so I tried that and thought well this is probably something users would want to be able to control, so I added that as well. Fixed a few little nitpicks like missing periods in the docstrings as well.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
