### PR TITLE
OpenSpiel: fix reset() with no seed, make obs/act spaces match PettingZoo

### DIFF
--- a/shimmy/openspiel_compatibility.py
+++ b/shimmy/openspiel_compatibility.py
@@ -188,15 +188,17 @@ class OpenSpielCompatibilityV0(pz.AECEnv, EzPickle):
 
         # seed argument is only valid for three games
         if self.game_name in ["deep_sea", "hanabi", "mfg_garnet"] and seed is not None:
-            if self.config is None:
-                reset_config = {"seed": seed}
-            else:
-                reset_config = self.config.copy() if self.config is not None else {}
+            if self.config is not None:
+                reset_config = self.config.copy()
                 reset_config["seed"] = seed
+            else:
+                reset_config = {"seed": seed}
             self._env = pyspiel.load_game(self.game_name, reset_config)
-
         else:
-            self._env = pyspiel.load_game(self.game_name, self.config)
+            if self.config is not None:
+                self._env = pyspiel.load_game(self.game_name, self.config)
+            else:
+                self._env = pyspiel.load_game(self.game_name)
 
         # all agents
         self.agents = self.possible_agents[:]


### PR DESCRIPTION
# Description

This was a minor typo where the config was not passed into the reloading of a game if the seed was not specified. I also changed the observation/action spaces to match PettingZoo's format, as it isn't very intuitive to have them indexed by number rather than agent ID. The action mask was by agent but the obs space was not. This makes it much more straightforward to adapt this wrapper to be used for other PZ environments (for example Jordan wanted to add Shogi)

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
