### PR TITLE
Build wheels without using setup.py (python -m build)

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -40,9 +40,9 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
-      run: python -m pip install --upgrade setuptools wheel
+      run: python -m pip install --upgrade setuptools wheel build
     - name: Build wheels
-      run: python setup.py sdist bdist_wheel
+      run: python -m build --sdist --wheel
     - name: Store wheels
       uses: actions/upload-artifact@v2
       with:

--- a/tests/test_dm_control.py
+++ b/tests/test_dm_control.py
@@ -55,6 +55,7 @@ CHECK_ENV_IGNORE_WARNINGS = [
         "It seems a Box observation space is an image but the upper and lower bounds are not in [0, 255]. Generally, CNN policies assume observations are within that range, so you may encounter an issue if the observation values are not.",
         "arrays to stack must be passed as a 'sequence' type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.",
         "Calling `env.close()` on the closed environment should be allowed, but it raised an exception: _data",
+        "Calling `env.close()` on the closed environment should be allowed, but it raised an exception: 'Physics' object has no attribute '_data'",
     ]
 ]
 CHECK_ENV_IGNORE_WARNINGS.append(


### PR DESCRIPTION
# Description

Using setup.py to build wheels can result in some unexpected behavior on certain systems and python versions, the recommended way to do it is with `python -m build` (or python3 -m build), had some issues with SuperSuit with this and 3.11, so best to do this for future best practices.

For reference https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#packaging-your-project

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
