### PR TITLE
fixing dm_control rendering bug when human mode is used

### DIFF
--- a/shimmy/dm_control_compatibility.py
+++ b/shimmy/dm_control_compatibility.py
@@ -112,6 +112,12 @@ class DmControlCompatibilityV0(gymnasium.Env[ObsType, np.ndarray], EzPickle):
         timestep = self._env.reset()
         obs, reward, terminated, truncated, info = dm_env_step2gym_step(timestep)
 
+        if self.render_mode == "human":
+            self.viewer.close()
+            self.viewer = MujocoRenderer(
+                self._env.physics.model.ptr, self._env.physics.data.ptr
+            )
+
         return obs, info
 
     def step(

--- a/shimmy/dm_control_multiagent_compatibility.py
+++ b/shimmy/dm_control_multiagent_compatibility.py
@@ -236,6 +236,12 @@ class DmControlMultiAgentCompatibilityV0(ParallelEnv, EzPickle):
         timestep = self._env.reset()
         observations, _, _, _, info = _unravel_ma_timestep(timestep, self.agents)
 
+        if self.render_mode == "human":
+            self.viewer.close()
+            self.viewer = MujocoRenderer(
+                self._env.physics.model.ptr, self._env.physics.data.ptr
+            )
+
         return observations, info
 
     def step(


### PR DESCRIPTION
There seems to be a bug at present, due to the fact that dm_control environments re-compile their physics (including the Model and Data structures) on each reset (to allow for, e.g., domain randomization). As such, rendering stops working after the first reset(). This commit fixes the problem by re-creating a new Viewer in the "human" mode.

Note that this problem is only related to "human" mode rendering, since the other pixel-based renderings call self._env.physics directly instead, which is guaranteed to be the latest (correct) object.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #90 


## Type of change

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] New and existing unit tests pass locally with my changes
