### PR TITLE
Enable the docs version selector (versioning: True)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,6 +81,7 @@ html_theme_options = {
     "light_logo": "img/shimmy.svg",
     "dark_logo": "img/shimmy-white.svg",
     "gtag": "G-07SGW5KKJF",
+    "versioning": True,
     "source_repository": "https://github.com/Farama-Foundation/Shimmy/",
     "source_branch": "main",
     "source_directory": "docs/",


### PR DESCRIPTION
## Problem

shimmy.farama.org already has versioned docs deployed — `/main/` and tagged versions (`v1.0.1` … `v2.0.1`, 8 in total) are live on `gh-pages`, and `/main/_static/versioning/versioning_menu.html` returns 200. But the version-selector dropdown never shows up, because the pages don't inject the selector script.

## Cause

The Celshast `furo` theme only injects the versioning script when **both** conditions hold (`furo/theme/furo/base.html`):

```jinja
{% if theme_versioning == True and theme_source_repository -%}
```

Shimmy's `conf.py` sets `source_repository` but is missing `"versioning": True`, so the block is skipped.

## Fix

Add `"versioning": True` to `html_theme_options`. Verified with a minimal furo build: without the flag the page contains `0` `versioningConfig` blocks; with it, `1` — and `githubUser`/`githubRepo` are correctly derived from `source_repository` (`Farama-Foundation/Shimmy`).

Since the version folders are already deployed, the dropdown will be fully populated (main + all tagged releases) once the docs rebuild and deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)