### PR TITLE
Preserve Discrete space `start` offset in gym-to-gymnasium conversion

### DIFF
--- a/shimmy/openai_gym_compatibility.py
+++ b/shimmy/openai_gym_compatibility.py
@@ -305,7 +305,7 @@ def _convert_space(space: gym.Space) -> gymnasium.Space:
         The converted space
     """
     if isinstance(space, gym.spaces.Discrete):
-        return Discrete(n=space.n)
+        return Discrete(n=space.n, start=getattr(space, "start", 0))
     elif isinstance(space, gym.spaces.Box):
         return Box(low=space.low, high=space.high, shape=space.shape, dtype=space.dtype)
     elif isinstance(space, gym.spaces.MultiDiscrete):

--- a/tests/test_gym.py
+++ b/tests/test_gym.py
@@ -109,3 +109,16 @@ def test_compatibility_get_attr():
     assert env.data == 123
     assert env.get_env_data() == 123
     env.close()
+
+
+@pytest.mark.skipif(
+    openai_gym.__version__ < "0.23",
+    reason="gym.spaces.Discrete gained the `start` parameter in gym 0.23",
+)
+def test_convert_discrete_space_preserves_start():
+    """Discrete.start offset must be preserved when converting gym -> gymnasium."""
+    space = openai_gym.spaces.Discrete(5, start=2)
+    converted = shimmy.openai_gym_compatibility._convert_space(space)
+    assert isinstance(converted, gymnasium.spaces.Discrete)
+    assert converted.n == 5
+    assert converted.start == 2


### PR DESCRIPTION
## What

`_convert_space()` in `shimmy/openai_gym_compatibility.py` dropped the `start` offset when converting a gym `Discrete` space to a gymnasium `Discrete`. It returned `Discrete(n=space.n)`, always defaulting `start` to `0`. This change forwards the offset: `Discrete(n=space.n, start=getattr(space, "start", 0))`.

## Why

gym gained a non-zero `Discrete.start` in gym 0.23 (the repo's `gym-v26` extra pins `gym==0.26.2`), and `gymnasium.spaces.Discrete` supports `start` too. Any gym env whose action/observation space is `Discrete(n, start=k)` with `k != 0` silently had its offset reset to `0` after conversion, mis-mapping every action/observation index. Preserving `start` fixes this data loss. `getattr(space, "start", 0)` keeps the call safe under gym 0.21.0, whose `Discrete` has no `start` attribute.

## Testing

Added `test_convert_discrete_space_preserves_start` to `tests/test_gym.py`, which converts `gym.spaces.Discrete(5, start=2)` and asserts the result is a `gymnasium.spaces.Discrete` with `n == 5` and `start == 2`. It fails on the unpatched code (`start == 0`) and passes with the fix. The test is `skipif`-guarded on `gym < "0.23"` because the `gym-v21` CI job installs gym 0.21.0, whose `Discrete` constructor rejects `start` (matching the existing string-version-comparison style in the file).

```
$ pytest tests/test_gym.py -q
..............                                                           [100%]
14 passed, 2 warnings in 0.17s
```
