### PR TITLE
fix: correct various issues with gym v21 compatibility env & update CI to work

### DIFF
--- a/shimmy/openai_gym_compatibility.py
+++ b/shimmy/openai_gym_compatibility.py
@@ -3,7 +3,7 @@
 # pyright: reportGeneralTypeIssues=false, reportPrivateImportUsage=false
 from __future__ import annotations
 
-from typing import Any, List, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 import gymnasium
 from gymnasium import error
@@ -152,7 +152,7 @@ class LegacyV21Env(Protocol):
         """Close the environment."""
         ...
 
-    def seed(self, seed: int | None = None) -> List[int] | None:
+    def seed(self, seed: int | None = None) -> list[int] | None:
         """Set the seed for this env's random number generator(s)."""
         ...
 

--- a/shimmy/openai_gym_compatibility.py
+++ b/shimmy/openai_gym_compatibility.py
@@ -3,7 +3,7 @@
 # pyright: reportGeneralTypeIssues=false, reportPrivateImportUsage=false
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, List, Protocol, runtime_checkable
 
 import gymnasium
 from gymnasium import error
@@ -152,7 +152,7 @@ class LegacyV21Env(Protocol):
         """Close the environment."""
         ...
 
-    def seed(self, seed: int | None = None):
+    def seed(self, seed: int | None = None) -> List[int] | None:
         """Set the seed for this env's random number generator(s)."""
         ...
 

--- a/shimmy/openai_gym_compatibility.py
+++ b/shimmy/openai_gym_compatibility.py
@@ -223,6 +223,9 @@ class GymV21CompatibilityV0(gymnasium.Env[ObsType, ActType]):
         Returns:
             (observation, info)
         """
+        # Initialise Gymnasium's RNG (check_env / seeding API expect `_np_random`).
+        super().reset(seed=seed)
+
         if seed is not None:
             self.gym_env.seed(seed)
 

--- a/tests/test_dm_control.py
+++ b/tests/test_dm_control.py
@@ -50,6 +50,10 @@ CHECK_ENV_IGNORE_WARNINGS = [
     ]
 ]
 CHECK_ENV_IGNORE_WARNINGS.append("`in1d` is deprecated. Use `np.isin` instead.")
+CHECK_ENV_IGNORE_WARNINGS.append(
+    "Setting the shape on a NumPy array has been deprecated in NumPy 2.5.\n"
+    "As an alternative, you can create a new view using np.reshape (with copy=False if needed)."
+)
 
 
 @pytest.mark.parametrize("env_id", DM_CONTROL_ENV_IDS)

--- a/tests/test_gym.py
+++ b/tests/test_gym.py
@@ -22,6 +22,8 @@ CHECK_ENV_IGNORE_WARNINGS = [
         "A Box observation space maximum value is infinity. This is probably too high.",
         "For Box action spaces, we recommend using a symmetric and normalized space (range=[-1, 1] or [0, 1]). See https://stable-baselines3.readthedocs.io/en/master/guide/rl_tips.html for more information.",
         "The environment CartPole-v0 is out of date. You should consider upgrading to version `v1`.",
+        "Official support for the `seed` function is dropped. Standard practice is to reset gymnasium environments "
+        "using `env.reset(seed=<desired seed>)`",
     ]
 ]
 CHECK_ENV_IGNORE_WARNINGS.append(

--- a/tests/test_gym.py
+++ b/tests/test_gym.py
@@ -28,6 +28,12 @@ CHECK_ENV_IGNORE_WARNINGS.append(
     "`np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)"
 )
 
+# Gym V26 introduced render_mode / the new step API; V21 uses the legacy API.
+if openai_gym.__version__ >= "0.26":
+    GYM_COMPAT_ENV_ID = "GymV26Environment-v0"
+else:
+    GYM_COMPAT_ENV_ID = "GymV21Environment-v0"
+
 # We do not test Atari environment's here because we check all variants of Pong in test_envs.py (There are too many Atari environments)
 if openai_gym.__version__ >= "0.24.0":
     CLASSIC_CONTROL_ENVS = [
@@ -48,7 +54,7 @@ else:
 )
 def test_gym_conversion_by_id(env_id):
     """Tests that the gym conversion works through specifying the env_id."""
-    env = gymnasium.make("GymV26Environment-v0", env_id=env_id).unwrapped
+    env = gymnasium.make(GYM_COMPAT_ENV_ID, env_id=env_id).unwrapped
 
     with warnings.catch_warnings(record=True) as caught_warnings:
         check_env(env, skip_render_check=True)
@@ -67,7 +73,7 @@ def test_gym_conversion_by_id(env_id):
 def test_gym_conversion_instantiated(env_id):
     """Tests that the gym conversion works with an instantiated gym environment."""
     env = openai_gym.make(env_id)
-    env = gymnasium.make("GymV26Environment-v0", env=env).unwrapped
+    env = gymnasium.make(GYM_COMPAT_ENV_ID, env=env).unwrapped
 
     print("render-mode", env.render_mode)
     print("render-modes", env.metadata)
@@ -88,8 +94,11 @@ class EnvWithData(openai_gym.Env):
 
     def __init__(self):
         """Initialises the environment with hidden data."""
-        self.observation_space = openai_Box(low=0, high=1)
-        self.action_space = openai_Box(low=0, high=1)
+        # gym 0.21 requires an explicit shape when low/high are scalars.
+        self.observation_space = openai_Box(low=0, high=1, shape=())
+        self.action_space = openai_Box(low=0, high=1, shape=())
+        # Present so GymV26CompatibilityV0 can read it on gym<0.26 installs.
+        self.render_mode = None
 
         self.data = 123
 

--- a/tests/test_gym.py
+++ b/tests/test_gym.py
@@ -22,8 +22,10 @@ CHECK_ENV_IGNORE_WARNINGS = [
         "A Box observation space maximum value is infinity. This is probably too high.",
         "For Box action spaces, we recommend using a symmetric and normalized space (range=[-1, 1] or [0, 1]). See https://stable-baselines3.readthedocs.io/en/master/guide/rl_tips.html for more information.",
         "The environment CartPole-v0 is out of date. You should consider upgrading to version `v1`.",
+        # Gym v21 warnings
         "Official support for the `seed` function is dropped. Standard practice is to reset gymnasium environments "
         "using `env.reset(seed=<desired seed>)`",
+        "Gym v21 environment do not accept options as a reset parameter, options={}",
     ]
 ]
 CHECK_ENV_IGNORE_WARNINGS.append(


### PR DESCRIPTION
# Description

1. Improve Gym v21 protocol correctness (`gym.Env.seed` returns `list[int] | None`)
2. Call `super().reset(seed=seed)` in Gym v21 reset
3. Fix various issues with unit tests & CI

Fixes #147 

Also opened this PR in upstream project `dm_control`:
- https://github.com/google-deepmind/dm_control/pull/539

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
