### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -14,6 +14,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build-wheels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Shimmy/security/code-scanning/2](https://github.com/Farama-Foundation/Shimmy/security/code-scanning/2)

Add an explicit `permissions` block to the workflow root so both jobs inherit least-privilege defaults.  
For this workflow, `contents: read` is the appropriate minimal baseline for checkout and artifact-related operations, and no broader write scope is required by the shown steps.

Best single fix (without changing functionality):
- Edit `.github/workflows/build-publish.yml`
- Insert a top-level `permissions:` block after the `on:` triggers (before `jobs:`), with:
  - `contents: read`

No imports, methods, or dependencies are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
