### PR TITLE
fix: restore broken DOI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![PyPI Version](https://img.shields.io/pypi/v/shimmy)](https://pypi.org/project/shimmy)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.8140744.svg)](https://doi.org/10.5281/zenodo.8140744)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.8140744-blue)](https://doi.org/10.5281/zenodo.8140744)
 
 <p align="center">
     <a href = "https://shimmy.farama.org/" target = "_blank"><img src="https://raw.githubusercontent.com/Farama-Foundation/Shimmy/main/shimmy-text.png" width="500px"/> </a>


### PR DESCRIPTION
## Summary
Fixes #151

The README DOI badge image was not rendering on GitHub. The DOI itself (`10.5281/zenodo.8140744`) is still valid and resolves to the Shimmy Zenodo record, but GitHub's image proxy (camo) returns HTTP 403 for `https://zenodo.org/badge/...` SVG URLs, so the badge shows as a broken image.

## Root cause
- Badge image URL: `https://zenodo.org/badge/DOI/10.5281/zenodo.8140744.svg`
- Direct fetch of that SVG still works
- GitHub camo fetch of the same URL returns 403, which breaks the badge on the repo page
- This matches the known 2026 Zenodo-on-GitHub badge breakage (e.g. scikit-learn#33840)

## Fix
Replace the Zenodo-hosted badge image with an equivalent shields.io badge that GitHub already proxies successfully for the other README badges:

```md
[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.8140744-blue)](https://doi.org/10.5281/zenodo.8140744)
```

- Keeps the same DOI link target (`https://doi.org/10.5281/zenodo.8140744`)
- Leaves the citation BibTeX block unchanged (DOI still correct)
- Confirmed against Zenodo API: record 8140744 is "Shimmy: Gymnasium and PettingZoo Wrappers for Commonly Used Environments" v1.1.0

## Test plan
- [x] `curl -sI` on old zenodo badge URL: 200 from zenodo, 403 via GitHub camo
- [x] `curl -sI` on new shields.io badge URL: 200
- [x] `curl -sIL https://doi.org/10.5281/zenodo.8140744` resolves to `https://zenodo.org/records/8140744`
- [ ] After merge, confirm DOI badge renders on https://github.com/Farama-Foundation/Shimmy